### PR TITLE
Use UITextView tint color for coloring the undeline and floating labe…

### DIFF
--- a/src/Xfx.Controls.iOS/Controls/FloatLabeledTextField.cs
+++ b/src/Xfx.Controls.iOS/Controls/FloatLabeledTextField.cs
@@ -57,12 +57,17 @@ namespace Xfx.Controls.iOS.Controls
             ErrorTextColor = UIColor.Red;
             ErrorTextIsVisible = false;
             FloatingLabelTextColor = UIColor.DarkGray;
-            FloatingLabelActiveTextColor = UIColor.Blue;
             FloatingLabelFont = UIFont.BoldSystemFontOfSize(12);
         }
 
         public UIColor FloatingLabelTextColor { get; set; }
-        public UIColor FloatingLabelActiveTextColor { get; set; }
+        public UIColor FloatingLabelActiveTextColor
+        {
+            get
+            {
+                return this.TintColor;
+            }
+        }
         public bool FloatingLabelEnabled { get; set; } = true;
         public UIColor ErrorTextColor
         {

--- a/src/Xfx.Controls.iOS/Renderers/XfxEntryRendererTouch.cs
+++ b/src/Xfx.Controls.iOS/Renderers/XfxEntryRendererTouch.cs
@@ -19,7 +19,13 @@ namespace Xfx.Controls.iOS.Renderers
     public class XfxEntryRendererTouch : ViewRenderer<XfxEntry, FloatLabeledTextField>
     {
         private readonly CGColor _defaultLineColor = Color.FromHex("#666666").ToCGColor();
-        private readonly CGColor _editingUnderlineColor = UIColor.Blue.CGColor;
+        private CGColor _editingUnderlineColor
+        {
+            get
+            {
+                return UITextView.Appearance.TintColor.CGColor;
+            }
+        }
         private UIColor _defaultPlaceholderColor;
         private UIColor _defaultTextColor;
         private bool _hasError;


### PR DESCRIPTION
One might want to customize the colors used by the floating label and underline.
On Android, this can already be done by customizing the theme or TextInputLayout in XML.

According to [this](https://stackoverflow.com/questions/32440811/change-textinputlayout-accent-color-programmatically) on Android, the colors cannot be changed without a hack, creating access to private color members.

So on iOS, the behavior should probably be similar: Use the theme color.

## Description

Changes Proposed in this pull request:
- Use TintColor for FloatingLabelActiveTextColor
- Use UITextView.Appearance.TintColor for _editingUnderlineColor

## This is a:
- [ ] Bug Fix
- [ ] Feature Request
- [X] New Feature
