### PR TITLE
Allow removing the space taken by the underline error label

### DIFF
--- a/src/Xfx.Controls.Droid/Renderers/XfxEntryRendererDroid.cs
+++ b/src/Xfx.Controls.Droid/Renderers/XfxEntryRendererDroid.cs
@@ -108,8 +108,7 @@ namespace Xfx.Controls.Droid.Renderers
                 SetFont();
                 SetFloatingHintEnabled();
                 SetIsEnabled();
-
-                Control.ErrorEnabled = true;
+                SetErrorDisplay();
             }
         }
 
@@ -213,6 +212,19 @@ namespace Xfx.Controls.Droid.Renderers
             Control.HintEnabled = Element.FloatingHintEnabled;
         }
 
+        public void SetErrorDisplay()
+        {
+            switch(Element.ErrorDisplay)
+            {
+                case ErrorDisplay.None:
+                    Control.ErrorEnabled = false;
+                    break;
+                case ErrorDisplay.Underline:
+                    Control.ErrorEnabled = true;
+                    break;
+            }
+        }
+
         protected void HideKeyboard()
         {
             var manager = (InputMethodManager) Application.Context.GetSystemService(Context.InputMethodService);
@@ -229,13 +241,11 @@ namespace Xfx.Controls.Droid.Renderers
         {
             if (!string.IsNullOrEmpty(Element.ErrorText))
             {
-                Control.ErrorEnabled = true;
                 Control.Error = Element.ErrorText;
             }
             else
             {
                 Control.Error = null;
-                Control.ErrorEnabled = false;
             }
         }
 

--- a/src/Xfx.Controls.iOS/Controls/FloatLabeledTextField.cs
+++ b/src/Xfx.Controls.iOS/Controls/FloatLabeledTextField.cs
@@ -76,7 +76,7 @@ namespace Xfx.Controls.iOS.Controls
         {
             get
             {
-                return UnderlineErrorSpaceEnabled ? 22 : 0;
+                return UnderlineErrorSpaceEnabled ? 22 : 4;
             }
         }
         public UIColor ErrorTextColor

--- a/src/Xfx.Controls.iOS/Controls/FloatLabeledTextField.cs
+++ b/src/Xfx.Controls.iOS/Controls/FloatLabeledTextField.cs
@@ -55,7 +55,7 @@ namespace Xfx.Controls.iOS.Controls
 
             BorderStyle = UITextBorderStyle.None;
             ErrorTextColor = UIColor.Red;
-            ErrorTextIsVisible = false;
+            UnderlineErrorTextIsVisible = false;
             FloatingLabelTextColor = UIColor.DarkGray;
             FloatingLabelFont = UIFont.BoldSystemFontOfSize(12);
         }
@@ -69,13 +69,23 @@ namespace Xfx.Controls.iOS.Controls
             }
         }
         public bool FloatingLabelEnabled { get; set; } = true;
+
+        public bool UnderlineErrorSpaceEnabled { get; set; } = true;
+
+        public float ErrorLabelSpace
+        {
+            get
+            {
+                return UnderlineErrorSpaceEnabled ? 22 : 0;
+            }
+        }
         public UIColor ErrorTextColor
         {
             get { return _errorLabel.TextColor; }
             set { _errorLabel.TextColor = value; }
         }
 
-        public bool ErrorTextIsVisible
+        public bool UnderlineErrorTextIsVisible
         {
             get { return !_errorLabel.Hidden; }
             set
@@ -136,7 +146,7 @@ namespace Xfx.Controls.iOS.Controls
             {
                 return base.TextRect(forBounds);
             }
-            return InsetRect(base.TextRect(forBounds), new UIEdgeInsets(_floatingLabel.Font.LineHeight, 0, 22, 0));
+            return InsetRect(base.TextRect(forBounds), new UIEdgeInsets(_floatingLabel.Font.LineHeight, 0, ErrorLabelSpace, 0));
         }
 
         public override CGRect EditingRect(CGRect forBounds)
@@ -146,7 +156,7 @@ namespace Xfx.Controls.iOS.Controls
                 return base.EditingRect(forBounds);
             }
 
-            return InsetRect(base.EditingRect(forBounds), new UIEdgeInsets(_floatingLabel.Font.LineHeight, 0, 22, 0));
+            return InsetRect(base.EditingRect(forBounds), new UIEdgeInsets(_floatingLabel.Font.LineHeight, 0, ErrorLabelSpace, 0));
         }
 
         public override CGRect ClearButtonRect(CGRect forBounds)
@@ -169,7 +179,7 @@ namespace Xfx.Controls.iOS.Controls
         {
             base.LayoutSubviews();
 
-            _underline.Frame = new CGRect(0f, Frame.Height - 20, Frame.Width, 1f);
+            _underline.Frame = new CGRect(0f, Frame.Height - ErrorLabelSpace + 2, Frame.Width, 1f);
 
             Action updateLabel = () =>
             {

--- a/src/Xfx.Controls.iOS/Controls/FloatLabeledTextField.cs
+++ b/src/Xfx.Controls.iOS/Controls/FloatLabeledTextField.cs
@@ -72,7 +72,7 @@ namespace Xfx.Controls.iOS.Controls
 
         public bool UnderlineErrorSpaceEnabled { get; set; } = true;
 
-        public float ErrorLabelSpace
+        public float UnderlineSpace
         {
             get
             {
@@ -146,7 +146,7 @@ namespace Xfx.Controls.iOS.Controls
             {
                 return base.TextRect(forBounds);
             }
-            return InsetRect(base.TextRect(forBounds), new UIEdgeInsets(_floatingLabel.Font.LineHeight, 0, ErrorLabelSpace, 0));
+            return InsetRect(base.TextRect(forBounds), new UIEdgeInsets(_floatingLabel.Font.LineHeight, 0, UnderlineSpace, 0));
         }
 
         public override CGRect EditingRect(CGRect forBounds)
@@ -156,7 +156,7 @@ namespace Xfx.Controls.iOS.Controls
                 return base.EditingRect(forBounds);
             }
 
-            return InsetRect(base.EditingRect(forBounds), new UIEdgeInsets(_floatingLabel.Font.LineHeight, 0, ErrorLabelSpace, 0));
+            return InsetRect(base.EditingRect(forBounds), new UIEdgeInsets(_floatingLabel.Font.LineHeight, 0, UnderlineSpace, 0));
         }
 
         public override CGRect ClearButtonRect(CGRect forBounds)
@@ -179,7 +179,7 @@ namespace Xfx.Controls.iOS.Controls
         {
             base.LayoutSubviews();
 
-            _underline.Frame = new CGRect(0f, Frame.Height - ErrorLabelSpace + 2, Frame.Width, 1f);
+            _underline.Frame = new CGRect(0f, Frame.Height - UnderlineSpace + 2, Frame.Width, 1f);
 
             Action updateLabel = () =>
             {

--- a/src/Xfx.Controls.iOS/Renderers/XfxEntryRendererTouch.cs
+++ b/src/Xfx.Controls.iOS/Renderers/XfxEntryRendererTouch.cs
@@ -67,8 +67,9 @@ namespace Xfx.Controls.iOS.Renderers
                 SetErrorText();
                 SetFont();
                 SetFloatingHintEnabled();
+                SetErrorDisplay();
 
-                Control.ErrorTextIsVisible = true;
+                Control.UnderlineErrorTextIsVisible = Element.ErrorDisplay == ErrorDisplay.Underline;
                 Control.EditingDidBegin += OnEditingDidBegin;
                 Control.EditingDidEnd += OnEditingDidEnd;
                 Control.EditingChanged += ViewOnEditingChanged;
@@ -141,11 +142,27 @@ namespace Xfx.Controls.iOS.Renderers
             Control.FloatingLabelEnabled = Element.FloatingHintEnabled;
         }
 
+        public void SetErrorDisplay()
+        {
+            switch (Element.ErrorDisplay)
+            {
+                case ErrorDisplay.None:
+                    Control.UnderlineErrorSpaceEnabled = false;
+                    Control.UnderlineErrorTextIsVisible = false;
+                    break;
+                case ErrorDisplay.Underline:
+                    Control.UnderlineErrorSpaceEnabled = true;
+                    _hasError = !string.IsNullOrEmpty(Element.ErrorText);
+                    Control.UnderlineErrorTextIsVisible = _hasError;
+                    break;
+            }
+        }
+
         private void SetErrorText()
         {
             _hasError = !string.IsNullOrEmpty(Element.ErrorText);
             Control.UnderlineColor = GetUnderlineColorForState();
-            Control.ErrorTextIsVisible = _hasError;
+            Control.UnderlineErrorTextIsVisible = _hasError && (Element.ErrorDisplay == ErrorDisplay.Underline);
             Control.ErrorText = Element.ErrorText;
         }
 

--- a/src/Xfx.Controls/XfxEntry.cs
+++ b/src/Xfx.Controls/XfxEntry.cs
@@ -25,11 +25,16 @@ namespace Xfx
         }
 
         /// <summary>
+        /// Gets or Sets whether or not the Error Style is 'Underline' or 'Tooltip'
+        /// </summary>
+        public ErrorDisplay ErrorDisplay { get; set; } = ErrorDisplay.Underline;
+
+        /// <summary>
         ///    Error text for the entry. An empty string removes the error. This is a bindable property.
         /// </summary>
         public string ErrorText
         {
-            get { return (string) GetValue(ErrorTextProperty); }
+            get { return (string)GetValue(ErrorTextProperty); }
             set { SetValue(ErrorTextProperty, value); }
         }
 
@@ -46,5 +51,11 @@ namespace Xfx
         }
 
         protected virtual void OnErrorTextChanged(BindableObject bindable, object oldvalue, object newvalue) { }
+    }
+
+    public enum ErrorDisplay
+    {
+        Underline,
+        None
     }
 }


### PR DESCRIPTION
## Description

Changes Proposed in this pull request:
- Adding an Option "ErrorDisplay" in XfxEntry with the possible values:
  - None: No Error is displayed
  - Underline: The Error is displayed below the Entry

## This is a:
- [ ] Bug Fix
- [ ] Feature Request
- [X] New Feature
