### PR TITLE
Fix issue #62

### DIFF
--- a/src/Xfx.Controls.Droid/Renderers/XfxComboBoxRendererDroid.cs
+++ b/src/Xfx.Controls.Droid/Renderers/XfxComboBoxRendererDroid.cs
@@ -24,7 +24,7 @@ namespace Xfx.Controls.Droid.Renderers
         {
         }
 
-        private AppCompatAutoCompleteTextView AutoComplete => (AppCompatAutoCompleteTextView)Control.EditText;
+        private AppCompatAutoCompleteTextView AutoComplete => (AppCompatAutoCompleteTextView)Control?.EditText;
 
         protected override TextInputLayout CreateNativeControl()
         {
@@ -40,12 +40,17 @@ namespace Xfx.Controls.Droid.Renderers
         protected override void OnElementChanged(ElementChangedEventArgs<XfxEntry> e)
         {
             base.OnElementChanged(e);
+
+            if (Element == null || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero || AutoComplete == null || AutoComplete.Handle == IntPtr.Zero)
+                return;
+
             if (e.OldElement != null)
             {
                 // unsubscribe
                 AutoComplete.ItemClick -= AutoCompleteOnItemSelected;
-                var elm = (Xfx.XfxComboBox) e.OldElement;
-                elm.CollectionChanged -= ItemsSourceCollectionChanged;
+
+                if (e.OldElement is Xfx.XfxComboBox elm)
+                    elm.CollectionChanged -= ItemsSourceCollectionChanged;
             }
 
             if (e.NewElement != null)
@@ -55,14 +60,18 @@ namespace Xfx.Controls.Droid.Renderers
                 SetThreshold();
                 KillPassword();
                 AutoComplete.ItemClick += AutoCompleteOnItemSelected;
-                var elm = (Xfx.XfxComboBox) e.NewElement;
-                elm.CollectionChanged += ItemsSourceCollectionChanged;
+
+                if (e.NewElement is Xfx.XfxComboBox elm)
+                    elm.CollectionChanged += ItemsSourceCollectionChanged;
             }
         }
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             base.OnElementPropertyChanged(sender, e);
+
+            if (Element == null || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero || AutoComplete == null || AutoComplete.Handle == IntPtr.Zero)
+                return;
 
             if (e.PropertyName == Entry.IsPasswordProperty.PropertyName)
                 KillPassword();
@@ -74,6 +83,10 @@ namespace Xfx.Controls.Droid.Renderers
 
         private void AutoCompleteOnItemSelected(object sender, AdapterView.ItemClickEventArgs args)
         {
+            // Method is called via event subscription which could result to a call to a disposed object.
+            if (Element == null || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero || AutoComplete == null || AutoComplete.Handle == IntPtr.Zero)
+                return;
+
             var view = (AutoCompleteTextView) sender;
             var selectedItemArgs = new SelectedItemChangedEventArgs(view.Text);
             var element = (Xfx.XfxComboBox) Element;
@@ -83,6 +96,10 @@ namespace Xfx.Controls.Droid.Renderers
 
         private void ItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
         {
+            // Method is called via event subscription which could result to a call to a disposed object.
+            if (Element == null || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero || AutoComplete == null || AutoComplete.Handle == IntPtr.Zero)
+                return;
+
             var element = (Xfx.XfxComboBox) Element;
             ResetAdapter(element);
         }

--- a/src/Xfx.Controls.Droid/Renderers/XfxEntryRendererDroid.cs
+++ b/src/Xfx.Controls.Droid/Renderers/XfxEntryRendererDroid.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Android.Content;
 using Android.Content.Res;
 using Android.Support.Design.Widget;
@@ -17,9 +18,9 @@ using Xfx;
 using Xfx.Controls.Droid.Extensions;
 using Xfx.Controls.Droid.Renderers;
 using Xfx.Extensions;
+using AColor = Android.Graphics.Color;
 using Application = Android.App.Application;
 using Color = Xamarin.Forms.Color;
-using AColor = Android.Graphics.Color;
 using FormsAppCompat = Xamarin.Forms.Platform.Android.AppCompat;
 
 [assembly: ExportRenderer(typeof(XfxEntry), typeof(XfxEntryRendererDroid))]
@@ -38,16 +39,20 @@ namespace Xfx.Controls.Droid.Renderers
             AutoPackage = false;
         }
 
-        protected EditText EditText => Control.EditText;
+        protected EditText EditText => Control?.EditText;
 
         public bool OnEditorAction(TextView v, ImeAction actionId, KeyEvent e)
         {
+            if (Element == null || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero)
+                return false;
+
             if ((actionId == ImeAction.Done) || ((actionId == ImeAction.ImeNull) && (e.KeyCode == Keycode.Enter)))
             {
                 Control.ClearFocus();
                 HideKeyboard();
                 ((IEntryController)Element).SendCompleted();
             }
+
             return true;
         }
 
@@ -61,8 +66,10 @@ namespace Xfx.Controls.Droid.Renderers
 
         public virtual void OnTextChanged(ICharSequence s, int start, int before, int count)
         {
-            if (string.IsNullOrWhiteSpace(Element.Text) && (s.Length() == 0)) return;
-            ((IElementController)Element).SetValueFromRenderer(Entry.TextProperty, s.ToString());
+            if (Element == null || (string.IsNullOrWhiteSpace(Element.Text) && (s.Length() == 0)) || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero)
+                return;
+
+            ((IElementController)Element)?.SetValueFromRenderer(Entry.TextProperty, s.ToString());
         }
 
         protected override TextInputLayout CreateNativeControl()
@@ -81,9 +88,11 @@ namespace Xfx.Controls.Droid.Renderers
         {
             base.OnElementChanged(e);
 
+            if (Element == null || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero)
+                return;
+
             if (e.OldElement != null)
-                if (Control != null)
-                    EditText.FocusChange -= ControlOnFocusChange;
+                EditText.FocusChange -= ControlOnFocusChange;
 
             if (e.NewElement != null)
             {
@@ -120,6 +129,9 @@ namespace Xfx.Controls.Droid.Renderers
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
+            if (Element == null || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero)
+                return;
+
             base.OnElementPropertyChanged(sender, e);
 
             if (e.PropertyName == Entry.PlaceholderProperty.PropertyName)
@@ -150,13 +162,24 @@ namespace Xfx.Controls.Droid.Renderers
 
         private void ControlOnFocusChange(object sender, FocusChangeEventArgs args)
         {
+            // Method is called via event subscription which could result to a call to a disposed object.
+            if (Element == null || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero)
+                return;
+
             _hasFocus = args.HasFocus;
             if (_hasFocus)
             {
                 var manager = (InputMethodManager)Application.Context.GetSystemService(Context.InputMethodService);
 
+                if (manager == null || manager.Handle == IntPtr.Zero)
+                    return;
+
                 EditText.PostDelayed(() =>
                     {
+                        // Double check for null and disposed objects because this call is delayed.
+                        if (manager == null || manager.Handle == IntPtr.Zero || Element == null || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero)
+                            return;
+
                         EditText.RequestFocus();
                         manager.ShowSoftInput(EditText, 0);
                     },
@@ -168,9 +191,9 @@ namespace Xfx.Controls.Droid.Renderers
             SetUnderlineColor(_hasFocus ?  GetActivePlaceholderColor(): GetPlaceholderColor());
         }
 
-        protected AColor GetPlaceholderColor() => Element.PlaceholderColor.ToAndroid(Color.FromHex("#80000000"));
+        protected AColor GetPlaceholderColor() => Element?.PlaceholderColor.ToAndroid(Color.FromHex("#80000000")) ?? Color.FromHex("#80000000").ToAndroid();
 
-        private AColor GetActivePlaceholderColor() => Element.ActivePlaceholderColor.ToAndroid(global::Android.Resource.Attribute.ColorAccent, Context);
+        private AColor GetActivePlaceholderColor() => Element?.ActivePlaceholderColor.ToAndroid(Android.Resource.Attribute.ColorAccent, Context) ?? new AColor(Android.Resource.Attribute.ColorAccent);
 
         protected virtual void SetLabelAndUnderlineColor()
         {
@@ -185,7 +208,9 @@ namespace Xfx.Controls.Droid.Renderers
         private void SetUnderlineColor(AColor color)
         {
             var element = (ITintableBackgroundView)EditText;
-            element.SupportBackgroundTintList = ColorStateList.ValueOf(color);
+
+            if (element != null && element.Handle != IntPtr.Zero)
+                element.SupportBackgroundTintList = ColorStateList.ValueOf(color);
         }
 
         private void SetHintLabelActiveColor(AColor color)
@@ -245,14 +270,14 @@ namespace Xfx.Controls.Droid.Renderers
             }
         }
 
-        public void SetFloatingHintEnabled()
+        private void SetFloatingHintEnabled()
         {
             Control.HintEnabled = Element.FloatingHintEnabled;
             Control.HintAnimationEnabled = Element.FloatingHintEnabled;
             SetFontAttributesSizeAndFamily();
         }
 
-        public void SetErrorDisplay()
+        private void SetErrorDisplay()
         {
             switch (Element.ErrorDisplay)
             {
@@ -268,6 +293,11 @@ namespace Xfx.Controls.Droid.Renderers
         protected void HideKeyboard()
         {
             var manager = (InputMethodManager)Application.Context.GetSystemService(Context.InputMethodService);
+
+            // Method is called via event subscription which could result to a call to a disposed object.
+            if (manager == null || manager.Handle == IntPtr.Zero || Element == null || Control == null || Control.Handle == IntPtr.Zero || EditText == null || EditText.Handle == IntPtr.Zero)
+                return;
+
             manager.HideSoftInputFromWindow(EditText.WindowToken, 0);
         }
 

--- a/src/Xfx.Controls.iOS/Renderers/XfxEntryRendererTouch.cs
+++ b/src/Xfx.Controls.iOS/Renderers/XfxEntryRendererTouch.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using CoreGraphics;
 using UIKit;
 using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
 using Xfx;
 using Xfx.Controls.iOS.Controls;
 using Xfx.Controls.iOS.Extensions;
@@ -11,7 +12,6 @@ using Xfx.Controls.iOS.Renderers;
 using Xfx.Extensions;
 using static Xamarin.Forms.Entry;
 using ColorExtensions = Xfx.Controls.iOS.Extensions.ColorExtensions;
-using Xamarin.Forms.Platform.iOS;
 
 [assembly: ExportRenderer(typeof(XfxEntry), typeof(XfxEntryRendererTouch))]
 
@@ -26,6 +26,9 @@ namespace Xfx.Controls.iOS.Renderers
         protected override void OnElementChanged(ElementChangedEventArgs<XfxEntry> e)
         {
             base.OnElementChanged(e);
+
+            if (Element == null || Control == null)
+                return;
 
             // unsubscribe
             if (e.OldElement != null)
@@ -61,6 +64,8 @@ namespace Xfx.Controls.iOS.Renderers
                 SetUnfocusedColor();
 
                 Control.UnderlineErrorTextIsVisible = Element.ErrorDisplay == ErrorDisplay.Underline;
+
+                // subscribe
                 Control.EditingDidBegin += OnEditingDidBegin;
                 Control.EditingDidEnd += OnEditingDidEnd;
                 Control.EditingChanged += ViewOnEditingChanged;
@@ -75,6 +80,9 @@ namespace Xfx.Controls.iOS.Renderers
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             base.OnElementPropertyChanged(sender, e);
+
+            if (Element == null || Control == null)
+                return;
 
             if (e.PropertyName == PlaceholderProperty.PropertyName)
                 SetHintText();
@@ -114,6 +122,10 @@ namespace Xfx.Controls.iOS.Renderers
 
         private void OnEditingDidEnd(object sender, EventArgs eventArgs)
         {
+            // Method is called via event subscription which could result to a call to a disposed object.
+            if (Element == null || Control == null)
+                return;
+
             var isFocusedPropertyKey = Element.GetInternalField<BindablePropertyKey>("IsFocusedPropertyKey");
             Element.SetValueFromRenderer(isFocusedPropertyKey, false);
             _hasFocus = false;
@@ -122,6 +134,10 @@ namespace Xfx.Controls.iOS.Renderers
 
         private void OnEditingDidBegin(object sender, EventArgs eventArgs)
         {
+            // Method is called via event subscription which could result to a call to a disposed object.
+            if (Element == null || Control == null)
+                return;
+
             var isFocusedPropertyKey = Element.GetInternalField<BindablePropertyKey>("IsFocusedPropertyKey");
             Element.SetValueFromRenderer(isFocusedPropertyKey, true);
             _hasFocus = true;
@@ -130,7 +146,11 @@ namespace Xfx.Controls.iOS.Renderers
 
         private void ViewOnEditingChanged(object sender, EventArgs eventArgs)
         {
-            Element?.SetValueFromRenderer(TextProperty, Control.Text);
+            // Method is called via event subscription which could result to a call to a disposed object.
+            if (Element == null || Control == null)
+                return;
+
+            Element.SetValueFromRenderer(TextProperty, Control.Text);
         }
 
         private void SetUnfocusedColor()


### PR DESCRIPTION
Add lots of null checks for Android and iOS renderers. Also add check for disposed objects (IntPtr.Zero) for Android. The crash appeared when the user left the content page really fast. Android has its own disposed object logic which leads to a behavior where the object is not null but its IntPtr is zero! In this case Android already disposed the object but it still has a reference. Therefore, it is recommended to always check for IntPtr.Zero by using the Handle method on native Android objects.

## Description

Changes proposed in this pull request:
- Fix issue #62 

## This is a:
- [x] Bug Fix
- [ ] Feature Request
- [ ] New Feature
