### PR TITLE
Use backwards compatible CardElevation property

### DIFF
--- a/src/Xfx.Controls.Droid/Renderers/XfxCardViewRendererDroid.cs
+++ b/src/Xfx.Controls.Droid/Renderers/XfxCardViewRendererDroid.cs
@@ -35,7 +35,7 @@ namespace Xfx.Controls.Droid.Renderers
         protected XfxCardView CardView => (XfxCardView)Element;
         protected virtual void OnElementChanged(object sender, VisualElementChangedEventArgs args) { }
         protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs args) { }
-        private void SetCardElevation() => Elevation = CardView.Elevation < 0 ? _defaultElevation : CardView.Elevation;
+        private void SetCardElevation() => CardElevation = CardView.Elevation < 0 ? _defaultElevation : CardView.Elevation;
         private void SetCardRadius() => Radius = CardView.CornerRadius < 0 ? _defaultCornerRadius : CardView.CornerRadius;
         private void SetCardBackgroundColor() => SetCardBackgroundColor(CardView.BackgroundColor.ToAndroid());
 
@@ -56,7 +56,7 @@ namespace Xfx.Controls.Droid.Renderers
             _visualElementManager.Init(this);
             UseCompatPadding = true;
 
-            _defaultElevation = Elevation;
+            _defaultElevation = CardElevation;
             _defaultCornerRadius = Radius;
             SetContentPadding();
             SetCardRadius();


### PR DESCRIPTION
## Description
Fix for Issue #61 and #67

Changes Proposed in this pull request:
- Use backwards compatible CardElevation property instead of the API 19 and lower incompatible property Elevation

## This is a:
- [x] Bug Fix
- [ ] Feature Request
- [ ] New Feature
