### PR TITLE
Demonstrate recommended string usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ The first two are pretty self explanitory, but here's an example of how you can 
 public class MyViewModel : INotifyPropertyChanged
 {
 	public Func<string, ICollection<string>, ICollection<string>> SortingAlgorithm { get; } = (text, values) => values
-		.Where(x => x.ToLower().StartsWith(text.ToLower()))
+		.Where(x => x.StartsWith(text, StringComparison.CurrentCultureIgnoreCase)))
 		.OrderBy(x => x)
 		.ToList();
 }

--- a/src/Xfx.Controls/XfxComboBox.cs
+++ b/src/Xfx.Controls/XfxComboBox.cs
@@ -36,7 +36,7 @@ namespace Xfx
         /// <example>
         /// <![CDATA[
         /// SortingAlgorithm = (text, values) => values
-        ///     .Where(t => t.ToLower().StartsWith(text.ToLower()))
+        ///     .Where(t => t.StartsWith(text, StringComparison.CurrentCultureIgnoreCase))
         ///     .OrderBy(x => x)
         ///     .ToList();
         /// ]]>


### PR DESCRIPTION
The [Recommendations for String Usage](https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings?view=netframework-4.8#recommendations-for-string-usage) avoids the extra copying caused by `ToLower`.
> Use overloads that explicitly specify the string comparison rules for string operations. Typically, this involves calling a method overload that has a parameter of type StringComparison.